### PR TITLE
Update draw-tools.user.js

### DIFF
--- a/plugins/draw-tools.user.js
+++ b/plugins/draw-tools.user.js
@@ -229,6 +229,22 @@ window.plugin.drawTools.getSnapLatLng = function(unsnappedLatLng) {
 
 
 window.plugin.drawTools.save = function() {
+  var layers = window.plugin.drawTools.drawnItems.getLayers();
+  layers.sort(function(a,b) {
+    aArea = L.GeometryUtil.geodesicArea(a.getLatLngs());
+    bArea = L.GeometryUtil.geodesicArea(b.getLatLngs());
+    if (aArea > bArea) {
+      return -1;
+    }
+    if (aArea < bArea) {
+      return 1;
+    }
+    return 0;
+  });
+  window.plugin.drawTools.drawnItems.clearLayers();
+  for (var layer of layers) {
+    window.plugin.drawTools.drawnItems.addLayer(layer);
+  }
   var data = [];
 
   window.plugin.drawTools.drawnItems.eachLayer( function(layer) {


### PR DESCRIPTION
Currently if a larger field is drawn over a small field and user tries to delete the small field, the large field is deleted instead. This sorts 